### PR TITLE
Fixes and updates for deployment of liberaforms v2.1.2 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -107,11 +107,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1659522808,
-        "narHash": "sha256-HBcM19nGhI3IWwPNVlYb0MZ8VW6iKp4JbAVkeIHVykc=",
+        "lastModified": 1666869603,
+        "narHash": "sha256-3V53or4Vpu4+LrGfGSh3T2V8+qf5RP6nRuex9GywkwE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "168d1c578909dc143ba52dbed661c36e76b12b36",
+        "rev": "2001e2b31c565bcdf7bc13062b8d7cfccaca05b8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
       (genConfig "container" self) // (genConfig "digitalocean" {inherit self serverCfg;});
 
     deploy.nodes = genAttrs' supportedSystems (s: "liberaforms-${s}") (system: {
-      hostname = serverCfg.domain;
+      hostname = "${serverCfg.hostname}.${serverCfg.domain}";
       profiles.system = {
         user = "root";
         sshUser = "root";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -3,7 +3,7 @@ inputs: final: prev: {
     req = builtins.readFile (inputs.liberaforms + "/requirements.txt");
     #TODO lots of notes here; mach-nix doesnt handle (??xref various issues) range of cryptography package - because it doesnt support pyproject.toml?
     #I don't like this, but doing this is the fastest way to get the cryptography from nixpkgs, which is at 36.0.0 (mach-nix automatically finds it)
-    filteredReq = builtins.replaceStrings ["cryptography==36.0.1"] ["cryptography==36.0.0"] req;
+    filteredReq = builtins.replaceStrings ["cryptography==36.0.1"] ["cryptography==36.0.0"] req; # for liberaforms > v2.0.1
     # Needed for tests only; TODO upstream should make a dev-requirements.txt or whatever?
     # https://gitlab.com/liberaforms/liberaforms/-/commit/16c893ff539bfb6249b3b02f4c834eb8848c16d5
     extraReq = "factory_boy";


### PR DESCRIPTION
I did a successful deploy of a WIP version of this updated flake to digital ocean back on September 16th. The changes to this PR version were mainly splitting things into commits and cleaning up leftover cruft from debugging so it should still work the same as it did then, but could be deploy tested again to be sure. 